### PR TITLE
Upgrading to Babel 6, eslint, and others

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,9 @@
 {
-    "optional": ["runtime"]
+    "presets": ["es2015"],
+    "plugins": [
+        ["transform-runtime", {
+            "polyfill": false,
+            "regenerator": true
+        }]
+    ]
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.js]
+indent_style = space
+indent_size = 4
+
+[*.{json,yml}]
+indent_style = space
+indent_size = 2

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+package
+example.js
+coverage_collector.js
+coverage

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 module.exports = {
     rules: {
         indent: [
@@ -23,8 +21,9 @@ module.exports = {
         es6: true,
         node: true
     },
-    ecmaFeatures: {
-        modules: true
+    parserOptions: {
+        sourceType: 'module',
+        ecmaVersion: 6
     },
     extends: 'eslint:recommended'
 };

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ build/Release
 # Deployed apps should consider commenting this line out:
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
-package/
+package/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 
-# test on two node.js versions: 0.6 and 0.8
+# test on two node.js versions: 0.6 and 0.8, 6.3.0
 node_js:
-  - 0.10.26
+  - 6.3.0

--- a/coverage_collector.js
+++ b/coverage_collector.js
@@ -1,7 +1,5 @@
-require('babel/polyfill');
-
 var fs = require('fs');
-var babel = require('babel');
+var babel = require('babel-core');
 var istanbul = require('istanbul');
 var COV_VAR = '______coverage______';
 

--- a/example.js
+++ b/example.js
@@ -5,7 +5,7 @@ let Participant = Factory(function() {
         id: this.uuid(),
         name: this.uniqId('name_'),
         email: this.uniqId('a@b.')
-    }
+    };
 });
 
 let Message = Factory(function() {
@@ -14,7 +14,7 @@ let Message = Factory(function() {
         subject: this.uuid(),
         from: this.factory(Participant),
         to: this.factories(Participant, 2)
-    }
+    };
 });
 
 let MessageWithAttachments = Message.extend(function(defaults) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,13 @@ var babel = require('gulp-babel');
 gulp.task('transpile', function() {
     gulp.src('src/**/*.js')
         .pipe(babel({
-            optional: ['runtime']
+            presets: ['es2015'],
+            plugins: [
+                ['transform-runtime', {
+                    polyfill: false,
+                    regenerator: true
+                }]
+            ]
         }))
         .pipe(gulp.dest('package'));
 });

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
  * Copyrights licensed under the New BSD License.
  * See the accompanying LICENSE file for terms.
  */
-
 require('babel/register')();
 
 module.exports = require('src/factory.js');

--- a/package.json
+++ b/package.json
@@ -1,37 +1,41 @@
 {
   "name": "sharkhorse",
-  "version": "3.0.8",
+  "version": "4.0.0",
   "description": "",
   "main": "./package/index.js",
   "files": [
     "package/"
   ],
   "scripts": {
-    "test": "gulp && ./node_modules/mocha/bin/mocha --compilers js:./coverage_collector.js test/*_test.js test/**/*_test.js &&     npm run test:package && cat ./coverage/coverage-final.json | ./node_modules/codecov.io/bin/codecov.io.js",
-    "test:dev": "./node_modules/mocha/bin/mocha --compilers js:babel/register test/*_test.js test/**/*_test.js",
-    "test:watch": "./node_modules/mocha/bin/mocha --compilers js:babel/register test/*_test.js test/**/*_test.js  --watch",
+    "build": "gulp",
+    "lint": "./node_modules/.bin/eslint .",
+    "test": "npm run lint && npm run build && ./node_modules/mocha/bin/mocha --compilers js:./coverage_collector.js test/*_test.js test/**/*_test.js && npm run test:package && cat ./coverage/coverage-final.json | ./node_modules/codecov.io/bin/codecov.io.js",
+    "test:dev": "./node_modules/mocha/bin/mocha --compilers js:babel-core/register test/*_test.js test/**/*_test.js",
+    "test:watch": "./node_modules/mocha/bin/mocha --compilers js:babel-core/register test/*_test.js test/**/*_test.js  --watch",
     "test:package": "./node_modules/mocha/bin/mocha package_test/*_test.js package_test/**/*_test.js"
   },
   "author": "Dmitrii Abramov",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "babel": "^5.8.23",
-    "chai": "^1.9.1",
+    "babel": "^6.5.2",
+    "babel-plugin-transform-runtime": "^6.9.0",
+    "babel-preset-es2015": "^6.9.0",
+    "chai": "^3.5.0",
     "codecov.io": "^0.1.6",
+    "eslint": "^3.0.1",
     "gulp": "^3.9.0",
-    "gulp-babel": "^5.3.0",
+    "gulp-babel": "^6.1.2",
     "istanbul": "gotwarlost/istanbul#source-map",
-    "jshint": "^2.5.6",
-    "lodash": "^3.10.1",
-    "mocha": "^1.21.4"
+    "lodash": "^4.13.1",
+    "mocha": "^2.5.3"
   },
   "repository": {
     "type": "git",
     "url": "git@github.com:dmitriiabramov/sharkhorse.git"
   },
   "dependencies": {
-    "babel-runtime": "^6.3.19",
-    "node-uuid": "1.4.1",
+    "babel-runtime": "~6.9.2",
+    "node-uuid": "^1.4.1",
     "prng": "0.0.1"
   }
 }

--- a/src/factory.js
+++ b/src/factory.js
@@ -21,7 +21,7 @@ export function create(descriptor, attributes) {
     }
 
     if (descriptor.constructor.name === 'Array') {
-        invariant(!attributes, `Can't pass attributes when array is passed to \`create\``);
+        invariant(!attributes, 'Can\'t pass attributes when array is passed to `create`');
         result = descriptor.map(el => el);
     } else {
         result = extend({}, descriptor, attributes);

--- a/src/generator_token.js
+++ b/src/generator_token.js
@@ -10,7 +10,7 @@
  * similar to `instanceof` but for functions
  */
 
-const IDENTIFIER = '8A12ABDF-FF00-4FDD-B8BD-EEC6B8D558F7'
+const IDENTIFIER = '8A12ABDF-FF00-4FDD-B8BD-EEC6B8D558F7';
 const TOKEN_PROP_NAME = 'sharkhorseGeneratorToken';
 import invariant from './invariant';
 

--- a/src/generators/date.js
+++ b/src/generators/date.js
@@ -41,12 +41,12 @@ export default function date() {
     next.unixTimestamp = () => {
         timestamp = 'unix';
         return next;
-    }
+    };
 
     next.jsTimestamp = () => {
         timestamp = 'js';
         return next;
-    }
+    };
 
     return next;
 }

--- a/src/generators/number.js
+++ b/src/generators/number.js
@@ -27,12 +27,12 @@ export default function number() {
     next.min = (value) => {
         min = value;
         return next;
-    }
+    };
 
     next.max = (value) => {
         max = value;
         return next;
-    }
+    };
 
     return next;
 }

--- a/src/invariant.js
+++ b/src/invariant.js
@@ -8,4 +8,4 @@ export default function invariant(condition, message) {
     if (!condition) {
         throw new Error(message);
     }
-};
+}

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    env: {
+        mocha: true
+    }
+}

--- a/test/deep_clone_test.js
+++ b/test/deep_clone_test.js
@@ -1,5 +1,3 @@
-
-
 import {expect} from 'chai';
 import {create, generators} from '../src';
 import _ from 'lodash';
@@ -12,9 +10,9 @@ describe('deep cloning', function() {
                     id: generators.sequence()
                 }
             }
-        }
+        };
 
-        let F2 = _.clone(F1, true)
+        let F2 = _.cloneDeep(F1, true);
 
         F2.nested1.nested2.id2 = generators.sequence();
 
@@ -30,9 +28,9 @@ describe('deep cloning', function() {
                     id: generators.sequence()
                 }
             }
-        }
+        };
 
-        let F2 = _.cloneDeep(F1)
+        let F2 = _.cloneDeep(F1);
 
         F2.nested1.nested2.id2 = generators.sequence();
 

--- a/test/generators/create_many_test.js
+++ b/test/generators/create_many_test.js
@@ -8,7 +8,7 @@ describe('generators/create_many', function() {
 
         expect(create(F2)).to.deep.equal({
             f: [{
-                a: 1,
+                a: 1
             }, {
                 a: 2
             }]


### PR DESCRIPTION
Babel config is now complying to 6.x
Eslintrc is now complying to 3.x

Is my changes to the runtime transform okay?